### PR TITLE
Add Holt backup service using .NET Generic Host

### DIFF
--- a/Holt.sln
+++ b/Holt.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Holt", "src\\Holt\\Holt.csproj", "{FECB217E-5433-4F6B-BA9B-D59C5689B86B}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{FECB217E-5433-4F6B-BA9B-D59C5689B86B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{FECB217E-5433-4F6B-BA9B-D59C5689B86B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{FECB217E-5433-4F6B-BA9B-D59C5689B86B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{FECB217E-5433-4F6B-BA9B-D59C5689B86B}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # Holt
-Holds and vaults Git repositories locally for safekeeping.
+
+Holt holds and vaults Git repositories locally for safekeeping.
+
+This repository contains the source for the **Holt** backup service.
+The service uses the .NET Generic Host and can run as a console
+application, a Windows service, or as a systemd service on Linux.
+
+Jobs are described by XML files placed in a configurable job directory
+(defaults to `jobs`). Each job specifies the repository URL, branch,
+local path, and the interval in minutes between synchronisations.
+Holt monitors the job directory for changes and starts, restarts, or
+stops jobs as the XML files are added, modified, or deleted.
+
+Logging uses the EventLog provider on Windows and the EventSource
+provider on other platforms.

--- a/jobs/sample-job.xml
+++ b/jobs/sample-job.xml
@@ -1,0 +1,7 @@
+<job>
+  <name>Sample</name>
+  <repositoryUrl>https://github.com/example/repo.git</repositoryUrl>
+  <branch>main</branch>
+  <localPath>backups/sample</localPath>
+  <intervalMinutes>60</intervalMinutes>
+</job>

--- a/src/Holt/Holt.csproj
+++ b/src/Holt/Holt.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>Holt</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="8.0.0" />
+    <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
+  </ItemGroup>
+</Project>

--- a/src/Holt/JobConfig.cs
+++ b/src/Holt/JobConfig.cs
@@ -1,0 +1,22 @@
+using System.Xml.Serialization;
+
+namespace Holt.Configuration;
+
+[XmlRoot("job")]
+public class JobConfig
+{
+    [XmlElement("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [XmlElement("repositoryUrl")]
+    public string RepositoryUrl { get; set; } = string.Empty;
+
+    [XmlElement("branch")]
+    public string Branch { get; set; } = "main";
+
+    [XmlElement("localPath")]
+    public string LocalPath { get; set; } = string.Empty;
+
+    [XmlElement("intervalMinutes")]
+    public int IntervalMinutes { get; set; } = 60;
+}

--- a/src/Holt/JobMonitorService.cs
+++ b/src/Holt/JobMonitorService.cs
@@ -1,0 +1,114 @@
+using System.Xml.Serialization;
+using Holt.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Holt.Services;
+
+public class JobMonitorService : BackgroundService
+{
+    private readonly ILogger<JobMonitorService> _logger;
+    private readonly IServiceProvider _services;
+    private readonly Dictionary<string, RepositoryJob> _jobs = new();
+    private FileSystemWatcher? _watcher;
+    private readonly string _jobDirectory;
+
+    public JobMonitorService(ILogger<JobMonitorService> logger, IServiceProvider services, IConfiguration configuration)
+    {
+        _logger = logger;
+        _services = services;
+        _jobDirectory = configuration["JobDirectory"] ?? Path.Combine(AppContext.BaseDirectory, "jobs");
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        if (!Directory.Exists(_jobDirectory))
+        {
+            Directory.CreateDirectory(_jobDirectory);
+        }
+
+        foreach (var file in Directory.GetFiles(_jobDirectory, "*.xml"))
+        {
+            StartOrUpdateJob(file);
+        }
+
+        _watcher = new FileSystemWatcher(_jobDirectory, "*.xml")
+        {
+            NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite
+        };
+        _watcher.Created += (s, e) => StartOrUpdateJob(e.FullPath);
+        _watcher.Changed += (s, e) => StartOrUpdateJob(e.FullPath);
+        _watcher.Deleted += (s, e) => RemoveJob(e.FullPath);
+        _watcher.Renamed += (s, e) =>
+        {
+            RemoveJob(e.OldFullPath);
+            StartOrUpdateJob(e.FullPath);
+        };
+        _watcher.EnableRaisingEvents = true;
+
+        return Task.CompletedTask;
+    }
+
+    private void StartOrUpdateJob(string path)
+    {
+        try
+        {
+            var config = LoadConfig(path);
+            if (config == null)
+            {
+                return;
+            }
+
+            if (_jobs.TryGetValue(path, out var existing))
+            {
+                existing.Dispose();
+                _jobs.Remove(path);
+            }
+
+            var jobLogger = _services.GetRequiredService<ILogger<RepositoryJob>>();
+            var job = new RepositoryJob(config, jobLogger);
+            job.Start();
+            _jobs[path] = job;
+            _logger.LogInformation("Started job {Name}", config.Name);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to start job from {Path}", path);
+        }
+    }
+
+    private void RemoveJob(string path)
+    {
+        if (_jobs.Remove(path, out var job))
+        {
+            job.Dispose();
+            _logger.LogInformation("Stopped job for {Path}", path);
+        }
+    }
+
+    private static JobConfig? LoadConfig(string path)
+    {
+        try
+        {
+            var serializer = new XmlSerializer(typeof(JobConfig));
+            using var stream = File.OpenRead(path);
+            return serializer.Deserialize(stream) as JobConfig;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public override Task StopAsync(CancellationToken cancellationToken)
+    {
+        _watcher?.Dispose();
+        foreach (var job in _jobs.Values)
+        {
+            job.Dispose();
+        }
+        _jobs.Clear();
+        return base.StopAsync(cancellationToken);
+    }
+}

--- a/src/Holt/Program.cs
+++ b/src/Holt/Program.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Holt.Services;
+
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+
+// Allow running as Windows service or systemd service
+builder.Host.UseWindowsService();
+builder.Host.UseSystemd();
+
+// Register background services
+builder.Services.AddHostedService<JobMonitorService>();
+
+// Configure logging
+if (OperatingSystem.IsWindows())
+{
+    builder.Logging.AddEventLog(config =>
+    {
+        config.SourceName = "Holt";
+    });
+}
+else
+{
+    builder.Logging.AddEventSourceLogger();
+}
+
+var host = builder.Build();
+
+await host.RunAsync();

--- a/src/Holt/RepositoryJob.cs
+++ b/src/Holt/RepositoryJob.cs
@@ -1,0 +1,87 @@
+using LibGit2Sharp;
+using Microsoft.Extensions.Logging;
+using Holt.Configuration;
+
+namespace Holt.Services;
+
+public class RepositoryJob : IDisposable
+{
+    private readonly JobConfig _config;
+    private readonly ILogger<RepositoryJob> _logger;
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _task;
+
+    public RepositoryJob(JobConfig config, ILogger<RepositoryJob> logger)
+    {
+        _config = config;
+        _logger = logger;
+    }
+
+    public void Start()
+    {
+        _task = Task.Run(RunAsync);
+    }
+
+    private async Task RunAsync()
+    {
+        await EnsureCloneAsync();
+
+        while (!_cts.IsCancellationRequested)
+        {
+            try
+            {
+                await SyncAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error syncing {Name}", _config.Name);
+            }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromMinutes(_config.IntervalMinutes), _cts.Token);
+            }
+            catch (TaskCanceledException)
+            {
+                break;
+            }
+        }
+    }
+
+    private Task EnsureCloneAsync()
+    {
+        if (!Directory.Exists(_config.LocalPath))
+        {
+            _logger.LogInformation("Cloning {Url} into {Path}", _config.RepositoryUrl, _config.LocalPath);
+            Repository.Clone(_config.RepositoryUrl, _config.LocalPath);
+        }
+        return Task.CompletedTask;
+    }
+
+    private Task SyncAsync()
+    {
+        using var repo = new Repository(_config.LocalPath);
+        Commands.Fetch(repo, "origin", Array.Empty<string>(), new FetchOptions(), null);
+        var branch = repo.Branches[$"origin/{_config.Branch}"];
+        if (branch != null)
+        {
+            Commands.Checkout(repo, branch);
+            repo.Reset(ResetMode.Hard, branch.Tip);
+        }
+        return Task.CompletedTask;
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        try
+        {
+            _task?.Wait();
+        }
+        catch
+        {
+            // ignore
+        }
+        _cts.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- implement Holt backup service project using .NET 8 Generic Host
- watch XML job files to clone and sync repositories for backup
- add sample job file and documentation

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a050bf70808321a855917c7a5b73f6